### PR TITLE
Create console-inspired single-page portfolio

### DIFF
--- a/css/portfolio.css
+++ b/css/portfolio.css
@@ -1,0 +1,905 @@
+:root {
+  color-scheme: dark;
+  --bg: #04060b;
+  --surface: #0d111c;
+  --surface-alt: #101726;
+  --surface-panel: #121b2f;
+  --outline: #1f2a3c;
+  --outline-soft: #1a2334;
+  --accent: #5ee9ff;
+  --accent-warm: #f4c95d;
+  --text: #f1f5ff;
+  --text-dim: #96a3c0;
+  --mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --sans: "Space Grotesk", "Plus Jakarta Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100%;
+}
+
+body {
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Crect width='160' height='160' fill='%2304060b'/%3E%3Cpath d='M0 0H160V160H0V0ZM0 40H160M0 80H160M0 120H160M40 0V160M80 0V160M120 0V160' stroke='%23172338' stroke-width='1' opacity='0.6'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.4;
+  pointer-events: none;
+  z-index: 0;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200' viewBox='0 0 200 200'%3E%3Crect width='200' height='200' fill='none'/%3E%3Ccircle cx='20' cy='20' r='1' fill='%231d2739'/%3E%3Ccircle cx='120' cy='60' r='1' fill='%231d2739'/%3E%3Ccircle cx='60' cy='140' r='1' fill='%231d2739'/%3E%3Ccircle cx='180' cy='100' r='1' fill='%231d2739'/%3E%3Ccircle cx='150' cy='170' r='1' fill='%231d2739'/%3E%3Ccircle cx='30' cy='190' r='1' fill='%231d2739'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
+  opacity: 0.35;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.interface {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  z-index: 1;
+}
+
+.side-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 280px;
+  background: var(--surface);
+  border-right: 1px solid var(--outline);
+  display: flex;
+  flex-direction: column;
+  padding: 32px 28px;
+  gap: 32px;
+  z-index: 5;
+}
+
+.brand-block h1 {
+  margin: 8px 0 4px;
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.brand-block p {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.brand-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--surface-alt);
+  border: 1px solid var(--outline);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand-badge__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px rgba(94, 233, 255, 0.7);
+  animation: pulse 2.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.3);
+    opacity: 0.6;
+  }
+}
+
+.status-diagnostics {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--outline);
+  border-radius: 16px;
+  background: var(--surface-alt);
+}
+
+.status-line {
+  display: grid;
+  gap: 4px;
+}
+
+.status-line .label {
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  font-family: var(--mono);
+}
+
+.status-line .value {
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.nav-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.nav-button {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  transition: border-color 0.3s ease, transform 0.3s ease, background-color 0.3s ease;
+  font-size: 0.95rem;
+}
+
+.nav-button__marker {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--outline);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.nav-button:hover,
+.nav-button:focus-visible {
+  border-color: var(--outline);
+  transform: translateX(4px);
+}
+
+.nav-button:hover .nav-button__marker,
+.nav-button:focus-visible .nav-button__marker {
+  background: var(--accent);
+  box-shadow: 0 0 10px rgba(94, 233, 255, 0.7);
+}
+
+.signal-monitor {
+  margin-top: auto;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+  height: 50px;
+  align-items: end;
+  padding: 12px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--outline);
+  background: var(--surface-alt);
+}
+
+.signal-bar {
+  background: var(--accent);
+  height: 16px;
+  border-radius: 6px;
+  opacity: 0.8;
+  animation: signal 1.6s ease-in-out infinite;
+  animation-delay: var(--delay);
+}
+
+@keyframes signal {
+  0%,
+  100% {
+    height: 16px;
+    opacity: 0.5;
+  }
+  50% {
+    height: 44px;
+    opacity: 1;
+  }
+}
+
+.content {
+  margin-left: 280px;
+  height: 100vh;
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
+  scroll-padding-top: 60px;
+  backdrop-filter: none;
+}
+
+.content::-webkit-scrollbar {
+  width: 9px;
+}
+
+.content::-webkit-scrollbar-thumb {
+  background: var(--outline);
+  border-radius: 999px;
+}
+
+.panel {
+  position: relative;
+  min-height: 100vh;
+  padding: 120px 7vw 100px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  scroll-snap-align: start;
+}
+
+.panel__inner {
+  display: grid;
+  gap: 4rem;
+  align-items: center;
+}
+
+.panel--hero .panel__inner {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hero-copy {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-family: var(--mono);
+}
+
+.hero-copy h2,
+.panel-header h2,
+.panel--contact h2 {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+  line-height: 1.1;
+}
+
+.lead {
+  margin: 0;
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: var(--text-dim);
+}
+
+.hero-actions {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.action-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--accent);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  transition: background-color 0.3s ease, color 0.3s ease, transform 0.3s ease;
+}
+
+.action-chip:hover,
+.action-chip:focus-visible {
+  background: var(--accent);
+  color: #02141a;
+  transform: translateY(-2px);
+}
+
+.action-chip--outline {
+  border-color: var(--outline);
+  color: var(--text-dim);
+}
+
+.action-chip--outline:hover,
+.action-chip--outline:focus-visible {
+  color: #02141a;
+}
+
+.hero-orbit {
+  position: relative;
+  width: min(420px, 90%);
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+  border-radius: 50%;
+  background: var(--surface-panel);
+  border: 1px solid var(--outline);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  box-shadow: 0 25px 60px rgba(0, 0, 0, 0.35);
+}
+
+.orbit-ring {
+  position: absolute;
+  border-radius: 50%;
+  border: 1px dashed var(--outline);
+}
+
+.orbit-ring--outer {
+  width: 88%;
+  height: 88%;
+  animation: spin 28s linear infinite;
+}
+
+.orbit-ring--inner {
+  width: 58%;
+  height: 58%;
+  animation: spinReverse 22s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spinReverse {
+  to {
+    transform: rotate(-360deg);
+  }
+}
+
+.orbit-core {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  border: 1px solid var(--accent);
+  display: grid;
+  place-items: center;
+  text-transform: uppercase;
+  font-family: var(--mono);
+  letter-spacing: 0.3em;
+  font-size: 0.7rem;
+}
+
+.orbit-tags {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  color: var(--text-dim);
+  animation: orbitFloat 12s ease-in-out infinite;
+}
+
+@keyframes orbitFloat {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(6deg);
+  }
+}
+
+.orbit-tags li {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform-origin: 0 0;
+  padding: 6px 12px;
+  background: var(--surface-alt);
+  border: 1px solid var(--outline);
+  border-radius: 999px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+}
+
+.orbit-tags li:nth-child(1) {
+  transform: rotate(0deg) translate(0, -180px) rotate(0deg);
+}
+
+.orbit-tags li:nth-child(2) {
+  transform: rotate(72deg) translate(0, -180px) rotate(-72deg);
+}
+
+.orbit-tags li:nth-child(3) {
+  transform: rotate(144deg) translate(0, -180px) rotate(-144deg);
+}
+
+.orbit-tags li:nth-child(4) {
+  transform: rotate(216deg) translate(0, -180px) rotate(-216deg);
+}
+
+.orbit-tags li:nth-child(5) {
+  transform: rotate(288deg) translate(0, -180px) rotate(-288deg);
+}
+
+.scroll-indicator {
+  position: absolute;
+  bottom: 32px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  opacity: 0.7;
+}
+
+.indicator-line {
+  width: 2px;
+  height: 46px;
+  background: var(--outline);
+  position: relative;
+  overflow: hidden;
+}
+
+.indicator-line::after {
+  content: "";
+  position: absolute;
+  top: -40%;
+  left: 0;
+  width: 100%;
+  height: 40%;
+  background: var(--accent);
+  animation: indicator 1.8s linear infinite;
+}
+
+@keyframes indicator {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(250%);
+  }
+}
+
+.indicator-text {
+  font-size: 0.75rem;
+  font-family: var(--mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.panel-header {
+  display: grid;
+  gap: 1rem;
+  max-width: 720px;
+}
+
+.panel-description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--text-dim);
+}
+
+.project-console {
+  margin-top: 40px;
+  display: grid;
+  gap: 24px;
+  grid-template-columns: minmax(0, 2.2fr) minmax(280px, 1fr);
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.project-capsule {
+  border: 1px solid var(--outline);
+  border-radius: 18px;
+  padding: 20px;
+  background: var(--surface-alt);
+  display: grid;
+  gap: 14px;
+  min-height: 190px;
+  cursor: pointer;
+  transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+}
+
+.project-capsule header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.project-capsule h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.capsule-index {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  color: var(--text-dim);
+}
+
+.project-capsule p {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.project-capsule:hover,
+.project-capsule:focus-visible {
+  transform: translateY(-6px);
+  border-color: var(--accent);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.35);
+}
+
+.project-capsule--active {
+  border-color: var(--accent);
+  box-shadow: 0 30px 70px rgba(94, 233, 255, 0.15);
+}
+
+.project-readout {
+  border: 1px solid var(--outline);
+  border-radius: 20px;
+  padding: 26px;
+  background: var(--surface-panel);
+  display: grid;
+  gap: 18px;
+  align-content: start;
+}
+
+.readout-header h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.readout-header p {
+  margin: 6px 0 0;
+  color: var(--text-dim);
+}
+
+.readout-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.readout-tags span {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--outline);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+  font-family: var(--mono);
+}
+
+.readout-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: fit-content;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.readout-link::after {
+  content: "→";
+  transition: transform 0.3s ease;
+}
+
+.readout-link:hover::after {
+  transform: translateX(4px);
+}
+
+.data-board {
+  display: grid;
+  gap: 20px;
+  margin-top: 40px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.data-card {
+  border: 1px solid var(--outline);
+  border-radius: 18px;
+  background: var(--surface-alt);
+  padding: 22px;
+  display: grid;
+  gap: 12px;
+  min-height: 220px;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.data-card header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.data-label {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.data-period {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  font-family: var(--mono);
+}
+
+.data-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.data-card p {
+  margin: 0;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+
+.data-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 25px 55px rgba(0, 0, 0, 0.35);
+}
+
+.panel--contact .panel__inner {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+}
+
+.contact-grid {
+  display: contents;
+}
+
+.contact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.contact-terminal {
+  border: 1px solid var(--outline);
+  border-radius: 20px;
+  background: var(--surface-panel);
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(94, 233, 255, 0.05);
+}
+
+.terminal-header {
+  padding: 16px 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--surface-alt);
+  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.terminal-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-warm);
+  box-shadow: 0 0 16px rgba(244, 201, 93, 0.7);
+}
+
+.terminal-body {
+  padding: 22px;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  display: grid;
+  align-content: start;
+  gap: 12px;
+}
+
+.site-footer {
+  margin-top: 60px;
+  border-top: 1px solid var(--outline);
+  padding-top: 24px;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.boot-screen {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: #010203;
+  z-index: 999;
+  transition: opacity 0.8s ease;
+}
+
+.boot-screen.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.boot-screen__inner {
+  text-align: center;
+  display: grid;
+  gap: 22px;
+}
+
+.boot-logo {
+  font-size: 2.4rem;
+  letter-spacing: 0.2em;
+  font-family: var(--mono);
+}
+
+.boot-logo span {
+  color: var(--accent);
+}
+
+.boot-lines {
+  font-family: var(--mono);
+  font-size: 0.9rem;
+  color: var(--text-dim);
+  display: grid;
+  gap: 6px;
+  text-align: left;
+  max-width: 420px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 1100px) {
+  .panel--hero .panel__inner,
+  .panel--contact .panel__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-orbit {
+    order: -1;
+  }
+
+  .panel {
+    padding: 100px 6vw 80px;
+  }
+}
+
+@media (max-width: 960px) {
+  .interface {
+    flex-direction: column;
+  }
+
+  .side-nav {
+    position: static;
+    width: auto;
+    border-right: none;
+    border-bottom: 1px solid var(--outline);
+    flex-direction: column;
+    gap: 24px;
+    padding: 24px;
+  }
+
+  .signal-monitor {
+    display: none;
+  }
+
+  .nav-panel {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .content {
+    margin-left: 0;
+    height: auto;
+    overflow: visible;
+    scroll-snap-type: none;
+  }
+
+  .panel {
+    min-height: auto;
+    padding: 80px 6vw;
+  }
+
+  .scroll-indicator {
+    position: static;
+    transform: none;
+    margin-top: 30px;
+  }
+}
+
+@media (max-width: 640px) {
+  .brand-block h1 {
+    font-size: 1.4rem;
+  }
+
+  .nav-panel {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .project-console {
+    grid-template-columns: 1fr;
+  }
+
+  .readout-link {
+    letter-spacing: 0.08em;
+  }
+
+  .hero-copy h2,
+  .panel-header h2,
+  .panel--contact h2 {
+    font-size: clamp(2rem, 8vw, 2.8rem);
+  }
+
+  .hero-orbit {
+    width: 100%;
+  }
+
+  .orbit-tags li {
+    transform: none;
+    position: static;
+    margin: 6px;
+  }
+
+  .orbit-tags {
+    position: static;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+    animation: none;
+    margin-top: 20px;
+  }
+
+  .orbit-ring--outer,
+  .orbit-ring--inner {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,555 +1,329 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <title>Matteo Giorgetti - Personal Portfolio</title>
-        <meta name="description" content="Matteo Giorgetti's personal portfolio showcasing projects, resume, and contact information." />
-        <meta name="author" content="Matteo Giorgetti" />
-        <title>Personal - Start Bootstrap Theme</title>
-        <!-- Favicon-->
-        <link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
-        <!-- Custom Google font-->
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-        <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@100;200;300;400;500;600;700;800;900&amp;display=swap" rel="stylesheet" />
-        <!-- Bootstrap icons-->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css" rel="stylesheet" />
-        <!-- Core theme CSS (includes Bootstrap)-->
-        <link href="/css/styles.css" rel="stylesheet" />
-    </head>
-    <body class="d-flex flex-column h-100">
-        <main class="flex-shrink-0">
-            <!-- Navigation-->
-            <nav class="navbar navbar-expand-lg navbar-dark py-3">
-                <div class="container px-5">
-                    <a class="navbar-brand" href="/index.html"><span class="fw-bolder">Matteo Giorgetti</span></a>
-                    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-                    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 small fw-bolder">
-                            <li class="nav-item"><a class="nav-link text-light" href="/index.html">Home</a></li>
-                            <li class="nav-item"><a class="nav-link text-light" href="/resume.html">Resume</a></li>
-                            <li class="nav-item"><a class="nav-link text-light" href="/projects.html">Projects</a></li>
-                            <li class="nav-item"><a class="nav-link text-light" href="/contact.html">Contact</a></li>
-                        </ul>                        
-                    </div>
-                </div>
-            </nav>
-            <!-- Header-->
-            <header class="py-5">
-                <div class="container px-5 pb-5">
-                    <div class="row gx-5 align-items-center">
-                        <div class="col-xxl-5">
-                            <!-- Header text content-->
-                            <div class="text-center text-xxl-start">
-                                <div class="badge bg-gradient-primary-to-secondary text-white mb-4"><div class="text-uppercase">Code &middot; AI &middot; Innovation</div></div>
-                                <!--<div class="fs-3 fw-light text-muted">I am a passionate gamer and programmer.</div>-->
-                                <h1 class="display-3 fw-bolder mb-5"><span class="text-gradient d-inline">Innovating with Code</span></h1>
-                                <div class="d-grid gap-3 d-sm-flex justify-content-sm-center justify-content-xxl-start mb-3">
-                                    <a class="btn btn-primary btn-lg px-5 py-3 me-sm-3 fs-6 fw-bolder" href="/resume.html">Resume</a>
-                                    <a class="btn btn-outline-dark btn-lg px-5 py-3 fs-6 fw-bolder" href="/projects.html">Projects</a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xxl-7">
-                            <!-- Header profile picture-->
-                            <div class="d-flex justify-content-center mt-5 mt-xxl-0">
-                                <div class="profile bg-gradient-primary-to-secondary">
-                                    <!-- TIP: For best results, use a photo with a transparent background like the demo example below-->
-                                    <!-- Watch a tutorial on how to do this on YouTube (link)-->
-                                    <img class="profile-img" src="/assets/profile.png" alt="..." />
-                                    <div class="dots-1">
-                                        <!-- SVG Dots-->
-                                        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 191.6 1215.4" style="enable-background: new 0 0 191.6 1215.4" xml:space="preserve">
-                                            <g transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)">
-                                                <path d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"></path>
-                                                <path d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"></path>
-                                                <path d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"></path>
-                                                <path d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"></path>
-                                                <path d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"></path>
-                                                <path d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"></path>
-                                                <path d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"></path>
-                                                <path d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"></path>
-                                                <path d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"></path>
-                                                <path d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"></path>
-                                                <path d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"></path>
-                                                <path d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"></path>
-                                                <path d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"></path>
-                                                <path d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"></path>
-                                                <path d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"></path>
-                                                <path d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"></path>
-                                                <path d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"></path>
-                                                <path d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"></path>
-                                                <path d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"></path>
-                                                <path d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"></path>
-                                            </g>
-                                        </svg>
-                                        <!-- END of SVG dots-->
-                                    </div>
-                                    <div class="dots-2">
-                                        <!-- SVG Dots-->
-                                        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 191.6 1215.4" style="enable-background: new 0 0 191.6 1215.4" xml:space="preserve">
-                                            <g transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)">
-                                                <path d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"></path>
-                                                <path d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"></path>
-                                                <path d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"></path>
-                                                <path d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"></path>
-                                                <path d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"></path>
-                                                <path d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"></path>
-                                                <path d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"></path>
-                                                <path d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"></path>
-                                                <path d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"></path>
-                                                <path d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"></path>
-                                                <path d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"></path>
-                                                <path d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"></path>
-                                                <path d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"></path>
-                                                <path d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"></path>
-                                                <path d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"></path>
-                                                <path d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"></path>
-                                                <path d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"></path>
-                                                <path d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"></path>
-                                                <path d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"></path>
-                                                <path d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"></path>
-                                            </g>
-                                        </svg>
-                                        <!-- END of SVG dots-->
-                                    </div>
-                                    <div class="dots-3">
-                                        <!-- SVG Dots-->
-                                        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 191.6 1215.4" style="enable-background: new 0 0 191.6 1215.4" xml:space="preserve">
-                                            <g transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)">
-                                                <path d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"></path>
-                                                <path d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"></path>
-                                                <path d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"></path>
-                                                <path d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"></path>
-                                                <path d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"></path>
-                                                <path d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"></path>
-                                                <path d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"></path>
-                                                <path d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"></path>
-                                                <path d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"></path>
-                                                <path d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"></path>
-                                                <path d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"></path>
-                                                <path d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"></path>
-                                                <path d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"></path>
-                                                <path d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"></path>
-                                                <path d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"></path>
-                                                <path d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"></path>
-                                                <path d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"></path>
-                                                <path d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"></path>
-                                                <path d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"></path>
-                                                <path d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"></path>
-                                            </g>
-                                        </svg>
-                                        <!-- END of SVG dots-->
-                                    </div>
-                                    <div class="dots-4">
-                                        <!-- SVG Dots-->
-                                        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 191.6 1215.4" style="enable-background: new 0 0 191.6 1215.4" xml:space="preserve">
-                                            <g transform="translate(0.000000,1280.000000) scale(0.100000,-0.100000)">
-                                                <path d="M227.7,12788.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,12801.6,289.7,12808.6,227.7,12788.6z"></path>
-                                                <path d="M1507.7,12788.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,12801.6,1569.7,12808.6,1507.7,12788.6z"></path>
-                                                <path d="M227.7,11508.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,11521.6,289.7,11528.6,227.7,11508.6z"></path>
-                                                <path d="M1507.7,11508.6c-151-50-253-216-222-362c25-119,136-230,254-255c194-41,395,142,375,339c-11,105-90,213-190,262        C1663.7,11521.6,1569.7,11528.6,1507.7,11508.6z"></path>
-                                                <path d="M227.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,10241.6,289.7,10248.6,227.7,10228.6z"></path>
-                                                <path d="M1507.7,10228.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,10241.6,1569.7,10248.6,1507.7,10228.6z"></path>
-                                                <path d="M227.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,8961.6,289.7,8968.6,227.7,8948.6z"></path>
-                                                <path d="M1507.7,8948.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,8961.6,1569.7,8968.6,1507.7,8948.6z"></path>
-                                                <path d="M227.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,7681.6,289.7,7688.6,227.7,7668.6z"></path>
-                                                <path d="M1507.7,7668.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,7681.6,1569.7,7688.6,1507.7,7668.6z"></path>
-                                                <path d="M227.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,6401.6,289.7,6408.6,227.7,6388.6z"></path>
-                                                <path d="M1507.7,6388.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,6401.6,1569.7,6408.6,1507.7,6388.6z"></path>
-                                                <path d="M227.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,5121.6,289.7,5128.6,227.7,5108.6z"></path>
-                                                <path d="M1507.7,5108.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,5121.6,1569.7,5128.6,1507.7,5108.6z"></path>
-                                                <path d="M227.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,3841.6,289.7,3848.6,227.7,3828.6z"></path>
-                                                <path d="M1507.7,3828.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,3841.6,1569.7,3848.6,1507.7,3828.6z"></path>
-                                                <path d="M227.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,2561.6,289.7,2568.6,227.7,2548.6z"></path>
-                                                <path d="M1507.7,2548.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,2561.6,1569.7,2568.6,1507.7,2548.6z"></path>
-                                                <path d="M227.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C383.7,1281.6,289.7,1288.6,227.7,1268.6z"></path>
-                                                <path d="M1507.7,1268.6c-105-35-200-141-222-248c-43-206,163-412,369-369c155,32,275,190,260,339c-11,105-90,213-190,262        C1663.7,1281.6,1569.7,1288.6,1507.7,1268.6z"></path>
-                                            </g>
-                                        </svg>
-                                        <!-- END of SVG dots-->
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </header>
-            <!-- About Section-->
-            <section class="py-5" style="background-color: var(--bs-tertiary); color: var(--bs-light)">
-                <div class="container px-5">
-                    <div class="row gx-5 justify-content-center">
-                        <div class="col-xxl-8">
-                            <div class="text-center my-5">
-                                <h2 class="display-5 fw-bolder"><span class="text-gradient d-inline">About Me</span></h2>
-                                <p class="lead fw-light mb-4">Passionate about AI, software development, and problem-solving.</p>
-                                <p class="text-muted" style="color: var(--bs-light)">
-                                    I am Matteo Giorgetti, a Computer Science and Artificial Intelligence student at IE University.
-                                    My expertise spans software development, machine learning, and game development using Unreal Engine.
-                                    I've worked on projects ranging from AI-powered chatbots to financial analysis tools and game mechanics.
-                                    My goal is to innovate using AI, automation, and interactive technologies to enhance user experiences and solve real-world problems.
-                                </p>
-                                <div class="d-flex justify-content-center fs-2 gap-4">
-                                    <a class="text-gradient" href="https://www.linkedin.com/in/matteo-giorgetti-026172247/"><i class="bi bi-linkedin"></i></a>
-                                    <a class="text-gradient" href="https://github.com/Inventure71"><i class="bi bi-github"></i></a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <!-- Crystal Ball Bowl Section -->
-            <section class="bg-dark" style="padding-top: 0.5rem; padding-bottom: 2rem;">
-                <div class="container px-5">
-                    <div class="text-center" style="margin-bottom: 0.5rem;">
-                        <h2 class="display-5 fw-bolder"><span class="text-gradient d-inline">Discover My Projects</span></h2>
-                        <p class="lead fw-light text-light mb-0">Drag a crystal ball to the portal below to explore a project!</p>
-                    </div>
-                    <div id="crystal-ball-container" style="width: 100%; height: 450px; position: relative; margin: 0 auto;">
-                        <!-- Jar Background Layer -->
-                        <img src="/assets/Jar_background.png" alt="Jar Background" style="position: absolute; bottom: 5px; left: 50%; transform: translateX(-50%); width: 90%; max-width: 400px; height: auto; opacity: 0.7; pointer-events: none; z-index: 1;">
-                        
-                        <div id="project-drop-zone" style="position: absolute; top: 10px; left: 50%; transform: translateX(-50%); width: 150px; height: 70px; border: 2px dashed var(--bs-primary); border-radius: 10px; display: flex; align-items: center; justify-content: center; text-align: center; color: var(--bs-light); font-size: 0.9rem; z-index: 10; background-color: rgba(0,0,0,0.3); -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; user-select: none; pointer-events: none;">
-                            Drop Ball Here<br/>to Open Project
-                        </div>
-                        <canvas id="crystal-ball-canvas" style="position: relative; z-index: 2;"></canvas>
-                        
-                        <!-- Jar Foreground Layer -->
-                        <img src="/assets/Jar_foreground.png" alt="Jar Foreground" style="position: absolute; bottom: 5px; left: 50%; transform: translateX(-50%); width: 90%; max-width: 400px; height: auto; opacity: 0.7; pointer-events: none; z-index: 3;">
-                    </div>
-                </div>
-            </section>
-            <!-- Statistics Section -->
-            <section class="py-5" style="background-color: var(--bs-primary); color: var(--bs-light);">
-                <div class="container px-5">
-                <div class="row text-center">
-                    <div class="col-md-4 mb-4 mb-md-0">
-                    <h2 class="fw-bold">10</h2>
-                    <p class="mb-0">Projects Completed</p>
-                    </div>
-                    <div class="col-md-4 mb-4 mb-md-0">
-                    <h2 class="fw-bold">100+</h2>
-                    <p class="mb-0">Redbull drank</p>
-                    </div>
-                    <div class="col-md-4">
-                    <h2 class="fw-bold">Too many</h2>
-                    <p class="mb-0">Nights awake</p>
-                    </div>
-                </div>
-                </div>
-            </section>
-            <!-- Best Project Section 
-            <section class="py-5" style="background-color: var(--bs-dark); color: var(--bs-light);">
-                <div class="container px-5">
-                    <div class="row align-items-center">
-                        <div class="col-md-6">
-                            <h2 class="fw-bold">HoloVinyl - Augmented Reality Vinyl Player</h2>
-                            <p>
-                                HoloVinyl is an AI-powered augmented reality music experience that brings vinyl records to life.
-                                Users can scan a vinyl cover with their phone, and a holographic interface appears, allowing them to explore tracks, album history,
-                                and interactive visuals synced to the music. Leveraging AI-generated visualizations and real-time processing, HoloVinyl provides a unique way
-                                to experience classic and modern albums in a futuristic format.
-                            </p>
-                            <a href="project-details.html" class="btn btn-light">View Project</a>
-                        </div>
-                        <div class="col-md-6">
-                            <img src="assets/holovinyl.png" alt="Screenshot of HoloVinyl" class="img-fluid rounded">
-                        </div>
-                    </div>
-                </div>
-            </section>-->
-  
-  
-        </main>
-        <!-- Footer-->
-        <footer class="py-4 mt-auto" style="background-color: var(--bs-body-bg); color: var(--bs-light);">
-            <div class="container px-5">
-                <div class="row align-items-center justify-content-between flex-column flex-sm-row">
-                    <div class="col-auto"><div class="small m-0">Copyright &copy; https://inventure71.github.io 2025</div></div>
-                    <div class="col-auto">
-                        <a class="small" href="#!">Privacy</a>
-                        <span class="mx-1">&middot;</span>
-                        <a class="small" href="#!">Terms</a>
-                        <span class="mx-1">&middot;</span>
-                        <a class="small" href="#!">Contact</a>
-                    </div>
-                </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Matteo Giorgetti — Orbital Portfolio</title>
+    <meta
+      name="description"
+      content="An interactive console-style portfolio for Matteo Giorgetti highlighting AI, robotics, and creative technology projects."
+    />
+    <link rel="icon" type="image/png" href="/assets/favicon.ico" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/css/portfolio.css" />
+  </head>
+  <body>
+    <div class="boot-screen" id="boot-screen">
+      <div class="boot-screen__inner">
+        <div class="boot-logo">MG<span>71</span></div>
+        <div class="boot-lines" id="boot-lines" aria-live="polite"></div>
+      </div>
+    </div>
+
+    <div class="interface">
+      <aside class="side-nav">
+        <div class="brand-block">
+          <div class="brand-badge">
+            <span class="brand-badge__dot"></span>
+            <span class="brand-badge__label">LIVE</span>
+          </div>
+          <h1>Matteo Giorgetti</h1>
+          <p>Creative technologist building playful AI experiences.</p>
+        </div>
+
+        <div class="status-diagnostics">
+          <div class="status-line">
+            <span class="label">Current Focus</span>
+            <span class="value">AI Systems · Robotics · Immersive UI</span>
+          </div>
+          <div class="status-line">
+            <span class="label">Next Launch</span>
+            <span class="value">Self-directed research at IE University</span>
+          </div>
+        </div>
+
+        <nav class="nav-panel" aria-label="Primary">
+          <button class="nav-button" data-scroll="mission">
+            <span class="nav-button__marker"></span>
+            Mission Overview
+          </button>
+          <button class="nav-button" data-scroll="projects">
+            <span class="nav-button__marker"></span>
+            Project Deck
+          </button>
+          <button class="nav-button" data-scroll="lab">
+            <span class="nav-button__marker"></span>
+            Research Log
+          </button>
+          <button class="nav-button" data-scroll="contact">
+            <span class="nav-button__marker"></span>
+            Open Channel
+          </button>
+        </nav>
+
+        <div class="signal-monitor" aria-hidden="true">
+          <div class="signal-bar" style="--delay: 0s"></div>
+          <div class="signal-bar" style="--delay: 0.1s"></div>
+          <div class="signal-bar" style="--delay: 0.2s"></div>
+          <div class="signal-bar" style="--delay: 0.3s"></div>
+        </div>
+      </aside>
+
+      <main class="content" id="content">
+        <section class="panel panel--hero" id="mission">
+          <div class="panel__inner">
+            <div class="hero-copy">
+              <p class="eyebrow">Mission Control // Portfolio v3</p>
+              <h2>Inventive interfaces for human&nbsp;×&nbsp;machine collaboration.</h2>
+              <p class="lead">
+                I build AI-first experiences that feel tactile, narrative, and alive — from
+                story-driven games to robotics and productivity systems. Each project below is wired into this console with live
+                telemetry and interactive dossiers.
+              </p>
+              <div class="hero-actions">
+                <a class="action-chip" href="/resume.html">View Full Resume</a>
+                <a class="action-chip action-chip--outline" href="/projects.html">Legacy Projects</a>
+              </div>
             </div>
-        </footer>
-        <!-- Bootstrap core JS-->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-        <!-- Core theme JS-->
-        <script src="/js/scripts.js"></script>
-        <!-- Matter.js -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/matter-js/0.19.0/matter.min.js"></script>
-        <script>
-        // Profile image auto-switcher
-        (function() {
-            const images = [
-                '/assets/profile.png',
-                '/assets/profile2.png'
-            ];
-            const N = 1500; // milliseconds
-            let idx = 0;
-            const img = document.querySelector('.profile-img');
-            if (!img) return;
-            setInterval(() => {
-                idx = (idx + 1) % images.length;
-                img.src = images[idx];
-            }, N);
-        })();
+            <div class="hero-orbit" aria-hidden="true">
+              <div class="orbit-ring orbit-ring--outer"></div>
+              <div class="orbit-ring orbit-ring--inner"></div>
+              <div class="orbit-core">
+                <span class="core-label">Systems</span>
+              </div>
+              <ul class="orbit-tags">
+                <li>Budget Buddy</li>
+                <li>Neural Noir</li>
+                <li>HoloVinyl</li>
+                <li>VictorIA</li>
+                <li>ReminderZ</li>
+              </ul>
+            </div>
+          </div>
+          <div class="scroll-indicator">
+            <span class="indicator-line"></span>
+            <span class="indicator-text">Scroll or use the console</span>
+          </div>
+        </section>
 
-        // Crystal Ball Bowl Logic
-        (function() {
-            const container = document.getElementById('crystal-ball-container');
-            const canvas = document.getElementById('crystal-ball-canvas');
-            if (!container || !canvas) return;
+        <section class="panel" id="projects">
+          <div class="panel__inner">
+            <div class="panel-header">
+              <p class="eyebrow">Project Deck</p>
+              <h2>Modular showcases wired for exploration.</h2>
+              <p class="panel-description">
+                Select a capsule to reveal the mission briefing, tech stack, and jump through to the detailed field notes.
+              </p>
+            </div>
+            <div class="project-console">
+              <div class="project-grid" role="list">
+                <article
+                  class="project-capsule project-capsule--active"
+                  role="listitem"
+                  data-title="Budget Buddy"
+                  data-subtitle="AI-Powered Financial Chatbot"
+                  data-description="An AI co-pilot that surfaces spending insights, nudges better habits, and turns finances into conversational guidance."
+                  data-link="/project_details/project-budget-buddy.html"
+                  data-tags="Python,OpenAI API,LangChain,Streamlit"
+                >
+                  <header>
+                    <span class="capsule-index">01</span>
+                    <h3>Budget Buddy</h3>
+                  </header>
+                  <p>Conversational money intelligence that stays human in tone.</p>
+                </article>
+                <article
+                  class="project-capsule"
+                  role="listitem"
+                  data-title="Neural Noir"
+                  data-subtitle="AI-Driven Interactive Story Game"
+                  data-description="Procedurally generates noir mysteries that react to player decisions, blending narrative design with generative AI."
+                  data-link="/project_details/project-neural-noir.html"
+                  data-tags="Python,OpenAI API,Game Design,Prompt Engineering"
+                >
+                  <header>
+                    <span class="capsule-index">02</span>
+                    <h3>Neural Noir</h3>
+                  </header>
+                  <p>Dynamic murder-mystery episodes with branching AI dramaturgy.</p>
+                </article>
+                <article
+                  class="project-capsule"
+                  role="listitem"
+                  data-title="HoloVinyl"
+                  data-subtitle="Music &amp; Memory Integration Project"
+                  data-description="Links physical keepsakes to curated playlists so memories can be replayed with a tap — bridging tangible and digital sentiment."
+                  data-link="/project_details/project-holovinyl.html"
+                  data-tags="NFC Tags,React Native,UX Research,Experience Design"
+                >
+                  <header>
+                    <span class="capsule-index">03</span>
+                    <h3>HoloVinyl</h3>
+                  </header>
+                  <p>Analog touchstones that launch immersive, personal soundscapes.</p>
+                </article>
+                <article
+                  class="project-capsule"
+                  role="listitem"
+                  data-title="AI Pokémon Generator"
+                  data-subtitle="AI-Powered Pokémon Card Generator"
+                  data-description="Transforms playful prompts into bespoke trading cards with AI-crafted art, stats, and lore."
+                  data-link="/project_details/project-pokemon-card-generator.html"
+                  data-tags="Stable Diffusion,Python,Image Generation,UI Automation"
+                >
+                  <header>
+                    <span class="capsule-index">04</span>
+                    <h3>Pokémon Generator</h3>
+                  </header>
+                  <p>Whimsical creature design with a technical backbone.</p>
+                </article>
+                <article
+                  class="project-capsule"
+                  role="listitem"
+                  data-title="VictorIA"
+                  data-subtitle="AI-Powered Connect-4 Robotic Arm"
+                  data-description="A robotic arm that studies the grid, makes tactical moves, and keeps game night competitive through machine intelligence."
+                  data-link="/project_details/project-victoria.html"
+                  data-tags="Robotics,Computer Vision,Reinforcement Learning,Hardware"
+                >
+                  <header>
+                    <span class="capsule-index">05</span>
+                    <h3>VictorIA</h3>
+                  </header>
+                  <p>Physical gameplay enhanced with algorithmic strategy.</p>
+                </article>
+                <article
+                  class="project-capsule"
+                  role="listitem"
+                  data-title="ReminderZ"
+                  data-subtitle="Desktop Productivity Suite"
+                  data-description="A cross-platform productivity cockpit for notes, reminders, and AI-assisted project tracking."
+                  data-link="/project_details/project-remainder-v0.html"
+                  data-tags="Python,PyWebView,Task Automation,UX Systems"
+                >
+                  <header>
+                    <span class="capsule-index">06</span>
+                    <h3>ReminderZ</h3>
+                  </header>
+                  <p>Command center for personal knowledge and momentum.</p>
+                </article>
+              </div>
+              <aside class="project-readout" id="project-readout" aria-live="polite">
+                <div class="readout-header">
+                  <h3 id="readout-title">Budget Buddy</h3>
+                  <p id="readout-subtitle">AI-Powered Financial Chatbot</p>
+                </div>
+                <p id="readout-description">
+                  An AI co-pilot that surfaces spending insights, nudges better habits, and turns finances into conversational guidance.
+                </p>
+                <div class="readout-tags" id="readout-tags" aria-label="Technologies"></div>
+                <a class="readout-link" id="readout-link" href="/project_details/project-budget-buddy.html">
+                  Open mission log
+                </a>
+              </aside>
+            </div>
+          </div>
+        </section>
 
-            const projectLinks = [
-                { name: "Budget Buddy", url: "/project_details/project-budget-buddy.html" },
-                { name: "Neural Noir", url: "/project_details/project-neural-noir.html" },
-                { name: "HoloVinyl", url: "/project_details/project-holovinyl.html" },
-                { name: "AI Pokémon Card Generator", url: "/project_details/project-pokemon-card-generator.html" },
-                { name: "VictorIA", url: "/project_details/project-victoria.html" },
-                { name: "ReminderZ", url: "/project_details/project-remainder-v0.html" }
-            ];
+        <section class="panel" id="lab">
+          <div class="panel__inner">
+            <div class="panel-header">
+              <p class="eyebrow">Research Log</p>
+              <h2>Training grounds and community impact.</h2>
+              <p class="panel-description">
+                A selection of formative environments and initiatives that sharpened my craft, leadership, and curiosity.
+              </p>
+            </div>
+            <div class="data-board">
+              <article class="data-card">
+                <header>
+                  <span class="data-label">IE University</span>
+                  <span class="data-period">2024 – Present</span>
+                </header>
+                <h3>BSc Computer Science &amp; AI</h3>
+                <p>
+                  Exploring machine learning, computer vision, and generative design while prototyping immersive AI experiences across coursework and self-initiated labs.
+                </p>
+              </article>
+              <article class="data-card">
+                <header>
+                  <span class="data-label">H-FARM International School</span>
+                  <span class="data-period">2021 – 2024</span>
+                </header>
+                <h3>IB Diploma · Math &amp; Innovation</h3>
+                <p>
+                  Led research on neural network mathematics and co-created peer learning programs to make complex concepts approachable and fun.
+                </p>
+              </article>
+              <article class="data-card">
+                <header>
+                  <span class="data-label">Google Developer Student Clubs</span>
+                  <span class="data-period">2024 – Present</span>
+                </header>
+                <h3>Tech Guru &amp; Workshop Lead</h3>
+                <p>
+                  Facilitating hands-on sessions that translate AI theory into playful prototypes, connecting students with emerging tools.
+                </p>
+              </article>
+              <article class="data-card">
+                <header>
+                  <span class="data-label">VictorIA Robotics</span>
+                  <span class="data-period">2023</span>
+                </header>
+                <h3>AI Outreach</h3>
+                <p>
+                  Demonstrated the Connect-4 robotic arm to younger students and community partners, sparking interest in creative robotics applications.
+                </p>
+              </article>
+              <article class="data-card">
+                <header>
+                  <span class="data-label">Community Impact</span>
+                  <span class="data-period">2022 – 2024</span>
+                </header>
+                <h3>Tech Accessibility Initiatives</h3>
+                <p>
+                  Taught digital literacy to seniors and automated non-profit workflows, making technology supportive and inclusive for every generation.
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
 
-            const Engine = Matter.Engine, Render = Matter.Render, Runner = Matter.Runner, Bodies = Matter.Bodies, Composite = Matter.Composite, MouseConstraint = Matter.MouseConstraint, Mouse = Matter.Mouse, World = Matter.World, Events = Matter.Events, Body = Matter.Body;
+        <section class="panel panel--contact" id="contact">
+          <div class="panel__inner">
+            <div class="contact-grid">
+              <div>
+                <p class="eyebrow">Open Channel</p>
+                <h2>Let’s co-design the next experimental interface.</h2>
+                <p class="panel-description">
+                  I love projects that sit at the intersection of playful storytelling and intelligent systems. Tell me what you’re imagining and I’ll respond with prototypes, ideas, or questions that move it forward.
+                </p>
+                <div class="contact-actions">
+                  <a class="action-chip" href="mailto:matteo.giorgetti.05@gmail.com">matteo.giorgetti.05@gmail.com</a>
+                  <a class="action-chip action-chip--outline" href="/contact.html">Signal via contact form</a>
+                </div>
+              </div>
+              <div class="contact-terminal" aria-hidden="true">
+                <div class="terminal-header">
+                  <span class="terminal-dot"></span>
+                  Transmission Log
+                </div>
+                <div class="terminal-body" id="terminal-feed">
+                  <p>&gt; Awaiting next collaboration signal...</p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <footer class="site-footer">
+            <p>© <span id="year"></span> Matteo Giorgetti. Crafted inside an experimental console.</p>
+          </footer>
+        </section>
+      </main>
+    </div>
 
-            const engine = Engine.create({ gravity: { y: 0.4 } }); 
-            const world = engine.world;
-
-            const render = Render.create({
-                element: container,
-                canvas: canvas,
-                engine: engine,
-                options: {
-                    width: container.clientWidth,
-                    height: container.clientHeight,
-                    wireframes: false,
-                    background: 'transparent'
-                }
-            });
-            Render.run(render);
-            const runner = Runner.create();
-            Runner.run(runner, engine);
-
-            const canvasWidth = container.clientWidth;
-            const canvasHeight = container.clientHeight; // This height is for the canvas itself
-
-            // --- Create the Bowl --- 
-            const bowlSegments = [];
-            const bowlRadius = Math.min(canvasWidth, canvasHeight) * 0.4;
-            const bowlCenterX = canvasWidth / 2;
-            const bowlBottomY = canvasHeight * 0.85; 
-            const segmentAngleStep = Math.PI / 18; 
-            const bowlOpeningAngle = Math.PI / 2.5; 
-            const segmentLength = 25; 
-            const segmentThickness = 10; 
-            const bowlWallColor = 'rgba(100, 100, 100, 0.7)';
-
-            // Corrected angle loop for a proper bowl shape (open at the top)
-            // Angles are typically counter-clockwise from positive x-axis. Matter.js y is downwards.
-            // -PI/2 is top. PI/2 is bottom.
-            // We want walls from (top-left) around to (top-right)
-            const startAngle = -Math.PI / 2 + bowlOpeningAngle / 2; // e.g., -90deg + 36deg = -54deg (upper right opening edge)
-            const endAngle = (3 * Math.PI / 2) - bowlOpeningAngle / 2;   // e.g.,  270deg - 36deg = 234deg (upper left opening edge)
-
-            for (let angle = startAngle; angle <= endAngle; angle += segmentAngleStep) {
-                // Center of the circle forming the bowl's curve
-                const effectiveBowlCenterY = bowlBottomY - (bowlRadius * 0.7);
-                const x = bowlCenterX + bowlRadius * Math.cos(angle);
-                const y = effectiveBowlCenterY + bowlRadius * Math.sin(angle);
-                
-                const segment = Bodies.rectangle(x, y, segmentLength, segmentThickness, {
-                    isStatic: true,
-                    angle: angle + Math.PI / 2, 
-                    render: { visible: false } // Make original bowl segments invisible
-                });
-                bowlSegments.push(segment);
-            }
-            World.add(world, bowlSegments);
-
-            // --- Create Mixer Blade ---
-            const mixerBladeWidth = bowlRadius * 0.6;
-            const mixerBladeHeight = 10;
-            const mixerBlade = Bodies.rectangle(bowlCenterX, bowlBottomY - (segmentThickness/2) - 5, mixerBladeWidth, mixerBladeHeight, {
-                isStatic: false, // Will be moved kinematically
-                density: 0.1, // Give it some mass to push balls
-                friction: 0.1,
-                render: { fillStyle: 'rgba(150, 150, 150, 0.8)' } // Metallic gray
-            });
-            World.add(world, mixerBlade);
-
-            // Pin the mixer blade to the center of the bowl bottom using a constraint
-            const mixerPin = Matter.Constraint.create({
-                bodyA: mixerBlade,
-                pointB: { x: bowlCenterX, y: bowlBottomY - (segmentThickness/2) - 5 },
-                stiffness: 1,
-                length: 0,
-                render: { visible: false }
-            });
-            World.add(world, mixerPin);
-
-            Events.on(engine, 'beforeUpdate', function(event) {
-                Body.setAngularVelocity(mixerBlade, 0.05); 
-            });
-
-            const crystalColors = [
-                // Luminous Crystal Light Sources
-                { inner: 'rgba(255, 255, 255, 0.8)', outer: 'rgba(31, 70, 197, 0.35)' },  // Luminous Blue
-                { inner: 'rgba(255, 255, 255, 0.8)', outer: 'rgba(25, 135, 84, 0.35)' },  // Luminous Green
-                { inner: 'rgba(255, 255, 255, 0.8)', outer: 'rgba(13, 202, 240, 0.35)' },  // Luminous Cyan
-                { inner: 'rgba(255, 255, 255, 0.8)', outer: 'rgba(220, 220, 220, 0.30)' },// Luminous Light Gray/White
-                { inner: 'rgba(255, 255, 255, 0.8)', outer: 'rgba(111, 66, 193, 0.35)' } // Luminous Purple
-            ];
-
-            const balls = [];
-            const numBalls = 20; 
-            const ballRadius = 15; 
-
-            for (let i = 0; i < numBalls; i++) {
-                // Ensure balls start within the bowl, above the mixer
-                // Try to spawn them more towards the center and above the bottom part of the bowl arc
-                const spawnRadius = bowlRadius * 0.5; // Spawn within 50% of bowl radius
-                const randomAngle = Math.random() * Math.PI + Math.PI/2; // Spawn in bottom half of a circle
-                const initialX = bowlCenterX + spawnRadius * Math.cos(randomAngle);
-                // Y position: start from center of bowl arc and go slightly up or down, but above mixer
-                const effectiveBowlCenterY = bowlBottomY - (bowlRadius * 0.7);
-                const initialY = effectiveBowlCenterY + spawnRadius * Math.sin(randomAngle) - ballRadius;
-
-
-                const randomColorSet = crystalColors[Math.floor(Math.random() * crystalColors.length)];
-                const randomProject = projectLinks[Math.floor(Math.random() * projectLinks.length)];
-
-                const ball = Bodies.circle(initialX, initialY, ballRadius, { // Use adjusted initialX, initialY
-                    restitution: 0.5, 
-                    friction: 0.02,    
-                    density: 0.0015,   
-                    render: { strokeStyle: 'transparent', lineWidth: 0 }
-                });
-                ball.projectUrl = randomProject.url;
-                ball.projectName = randomProject.name;
-                ball.colorSet = randomColorSet; 
-                balls.push(ball);
-            }
-            World.add(world, balls);
-
-            Events.on(render, 'afterRender', function() {
-                const context = render.context;
-                balls.forEach(ball => {
-                    const gradient = context.createRadialGradient(ball.position.x, ball.position.y, 0, ball.position.x, ball.position.y, ballRadius);
-                    gradient.addColorStop(0, ball.colorSet.inner);
-                    gradient.addColorStop(1, ball.colorSet.outer);
-                    
-                    context.beginPath();
-                    context.arc(ball.position.x, ball.position.y, ballRadius, 0, 2 * Math.PI);
-                    context.fillStyle = gradient;
-                    context.fill();
-                });
-            });
-
-            const mouse = Mouse.create(render.canvas);
-            const mouseConstraint = MouseConstraint.create(engine, {
-                mouse: mouse,
-                constraint: {
-                    stiffness: 0.1, 
-                    render: { visible: false }
-                }
-            });
-            World.add(world, mouseConstraint);
-            render.mouse = mouse;
-
-            // Fix scrolling issue by removing wheel event listeners from MouseConstraint
-            mouse.element.removeEventListener('wheel', mouse.mousewheel);
-            mouse.element.removeEventListener('DOMMouseScroll', mouse.mousewheel);
-            mouse.element.removeEventListener('mousewheel', mouse.mousewheel);
-
-            // Variables to manage click vs. drag and drop zone
-            const dropZoneElement = document.getElementById('project-drop-zone');
-            let draggedBall = null;
-
-
-            Events.on(mouseConstraint, 'startdrag', function(event) {
-                if (balls.includes(event.body)) {
-                    draggedBall = event.body;
-                }
-            });
-
-            Events.on(mouseConstraint, 'enddrag', function(event) {
-                if (draggedBall && dropZoneElement) {
-                    const ballPosition = draggedBall.position;
-                    const dzRect = dropZoneElement.getBoundingClientRect();
-                    const canvasRect = canvas.getBoundingClientRect();
-
-                    const dzTop = dzRect.top - canvasRect.top;
-                    const dzLeft = dzRect.left - canvasRect.left;
-                    const dzRight = dzLeft + dzRect.width;
-                    const dzBottom = dzTop + dzRect.height;
-
-                    if (ballPosition.x >= dzLeft && ballPosition.x <= dzRight &&
-                        ballPosition.y >= dzTop && ballPosition.y <= dzBottom) {
-                        
-                        if (draggedBall.projectUrl) {
-                            console.log("Attempting to navigate to:", draggedBall.projectUrl);
-                            dropZoneElement.style.backgroundColor = 'rgba(var(--bs-success-rgb), 0.5)';
-                            dropZoneElement.textContent = 'Opening...';
-                            
-                            // Attempt navigation
-                            window.location.href = draggedBall.projectUrl;
-                        }
-                    }
-                }
-                draggedBall = null; 
-            });
-
-            // Optional: Highlight drop zone when a ball is dragged over it
-            Events.on(engine, 'beforeUpdate', function() {
-                if (draggedBall && dropZoneElement) {
-                    const ballPosition = draggedBall.position;
-                    const dzRect = dropZoneElement.getBoundingClientRect();
-                    const canvasRect = canvas.getBoundingClientRect();
-
-                    const dzTop = dzRect.top - canvasRect.top;
-                    const dzLeft = dzRect.left - canvasRect.left;
-                    const dzRight = dzLeft + dzRect.width;
-                    const dzBottom = dzTop + dzRect.height;
-
-                    if (ballPosition.x >= dzLeft && ballPosition.x <= dzRight &&
-                        ballPosition.y >= dzTop && ballPosition.y <= dzBottom) {
-                        dropZoneElement.style.borderColor = 'var(--bs-success)';
-                        dropZoneElement.style.boxShadow = '0 0 10px var(--bs-success)';
-                    } else {
-                        dropZoneElement.style.borderColor = 'var(--bs-primary)';
-                        dropZoneElement.style.boxShadow = 'none';
-                    }
-                } else if (dropZoneElement) { // Reset if no ball is being dragged
-                    dropZoneElement.style.borderColor = 'var(--bs-primary)';
-                    dropZoneElement.style.boxShadow = 'none';
-                }
-            });
-
-
-            Render.lookAt(render, { min: { x: 0, y: 0 }, max: { x: canvasWidth, y: canvasHeight } });
-            
-            // Basic resize handling (might need more robust solution for complex shapes)
-            // For this iteration, the bowl and mixer are not dynamically resized, 
-            // which might lead to visual issues if the container resizes significantly.
-            // A full solution would involve removing and re-creating these static/kinematic elements.
-            window.addEventListener('resize', function() {
-                const newWidth = container.clientWidth;
-                const newHeight = container.clientHeight;
-                render.options.width = newWidth;
-                render.options.height = newHeight;
-                render.canvas.width = newWidth;
-                render.canvas.height = newHeight;
-                // Note: Bowl segments and mixer are NOT resized/repositioned here.
-                // This would require recalculating their geometry and positions.
-                Render.lookAt(render, { min: { x: 0, y: 0 }, max: { x: newWidth, y: newHeight } });
-            });
-
-        })();
-        </script>
-    </body>
+    <script src="/js/scripts.js" defer></script>
+  </body>
 </html>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,7 +1,138 @@
-/*!
-* Start Bootstrap - Personal v1.0.1 (https://startbootstrap.com/template-overviews/personal)
-* Copyright 2013-2023 Start Bootstrap
-* Licensed under MIT (https://github.com/StartBootstrap/startbootstrap-personal/blob/master/LICENSE)
-*/
-// This file is intentionally blank
-// Use this file to add JavaScript to your project
+const bootLines = [
+  "Booting Orbital Portfolio v3.0...",
+  "Linking personal telemetry feeds...",
+  "Syncing AI-driven projects with console UI...",
+  "Establishing contact protocols...",
+  "System ready. Enjoy the tour."
+];
+
+const bootScreen = document.getElementById("boot-screen");
+const bootLinesElement = document.getElementById("boot-lines");
+
+(function renderBootSequence(lines, container) {
+  if (!container || !bootScreen) {
+    return;
+  }
+
+  let lineIndex = 0;
+
+  const typeNextLine = () => {
+    if (lineIndex >= lines.length) {
+      setTimeout(() => {
+        bootScreen.classList.add("is-hidden");
+      }, 600);
+      return;
+    }
+
+    const currentLine = lines[lineIndex];
+    const lineEl = document.createElement("span");
+    container.appendChild(lineEl);
+
+    let charIndex = 0;
+    const typeInterval = setInterval(() => {
+      lineEl.textContent = `> ${currentLine.slice(0, charIndex + 1)}`;
+      charIndex += 1;
+
+      if (charIndex === currentLine.length) {
+        clearInterval(typeInterval);
+        lineIndex += 1;
+        setTimeout(typeNextLine, 220);
+      }
+    }, 28);
+  };
+
+  typeNextLine();
+})(bootLines, bootLinesElement);
+
+const navButtons = document.querySelectorAll(".nav-button");
+
+navButtons.forEach((button) => {
+  const targetId = button.getAttribute("data-scroll");
+  button.addEventListener("click", () => {
+    const target = document.getElementById(targetId);
+    if (target) {
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  });
+});
+
+const capsules = document.querySelectorAll(".project-capsule");
+const readoutTitle = document.getElementById("readout-title");
+const readoutSubtitle = document.getElementById("readout-subtitle");
+const readoutDescription = document.getElementById("readout-description");
+const readoutTags = document.getElementById("readout-tags");
+const readoutLink = document.getElementById("readout-link");
+
+const activateCapsule = (capsule) => {
+  capsules.forEach((item) => item.classList.remove("project-capsule--active"));
+  capsule.classList.add("project-capsule--active");
+
+  if (readoutTitle) {
+    readoutTitle.textContent = capsule.dataset.title || "";
+  }
+  if (readoutSubtitle) {
+    readoutSubtitle.textContent = capsule.dataset.subtitle || "";
+  }
+  if (readoutDescription) {
+    readoutDescription.textContent = capsule.dataset.description || "";
+  }
+  if (readoutLink) {
+    readoutLink.href = capsule.dataset.link || "#";
+  }
+  if (readoutTags) {
+    readoutTags.innerHTML = "";
+    const tags = (capsule.dataset.tags || "")
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean);
+
+    tags.forEach((tag) => {
+      const tagEl = document.createElement("span");
+      tagEl.textContent = tag;
+      readoutTags.appendChild(tagEl);
+    });
+  }
+};
+
+capsules.forEach((capsule) => {
+  capsule.setAttribute("tabindex", "0");
+  capsule.addEventListener("click", () => activateCapsule(capsule));
+  capsule.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      activateCapsule(capsule);
+    }
+  });
+});
+
+const terminalFeed = document.getElementById("terminal-feed");
+const terminalMessages = [
+  "Signal received from Budget Buddy: conversational finances online.",
+  "VictorIA arm calibrated — ready for another round of Connect-4.",
+  "Neural Noir spun a fresh case file with unpredictable suspects.",
+  "ReminderZ synced tasks across devices without breaking focus.",
+  "HoloVinyl linked memories with bespoke playlists for a gallery night.",
+  "Pokémon Generator minted a new creature with lore-approved stats."
+];
+
+if (terminalFeed) {
+  let messageIndex = 0;
+  setInterval(() => {
+    messageIndex = (messageIndex + 1) % terminalMessages.length;
+    const paragraph = document.createElement("p");
+    paragraph.textContent = `> ${terminalMessages[messageIndex]}`;
+    terminalFeed.appendChild(paragraph);
+
+    const maxEntries = 6;
+    while (terminalFeed.children.length > maxEntries) {
+      terminalFeed.removeChild(terminalFeed.firstChild);
+    }
+
+    terminalFeed.scrollTop = terminalFeed.scrollHeight;
+  }, 5200);
+}
+
+const yearEl = document.getElementById("year");
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}


### PR DESCRIPTION
## Summary
- replace the Bootstrap-driven landing page with a console-style single-page portfolio experience and boot sequence overlay
- introduce a custom design system in `css/portfolio.css` featuring orbit visuals, scroll snapping, and interactive project capsules
- expand `js/scripts.js` to drive the boot typing effect, project readout interactions, and rotating contact terminal feed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f9dbb2b2a0832aada524d2b5f71918