### PR TITLE
Add Codex wall burst and particle effects for enhanced visual feedback

### DIFF
--- a/css/playfolio/motion.css
+++ b/css/playfolio/motion.css
@@ -59,6 +59,65 @@
   pointer-events: none;
 }
 
+.pf-codex-wall-burst {
+  position: absolute;
+  left: var(--burst-x);
+  top: var(--burst-y);
+  z-index: 24;
+  width: 1px;
+  height: 1px;
+  pointer-events: none;
+  animation: pf-codex-burst-life 560ms ease-out both;
+}
+
+.pf-codex-wall-particle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: var(--particle-size);
+  height: var(--particle-size);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 38% 32%, rgba(255, 255, 255, 0.98), rgba(255, 255, 255, 0.58) 28%, rgba(111, 134, 255, 0.72) 58%, rgba(63, 78, 255, 0) 72%);
+  box-shadow:
+    0 0 var(--particle-glow) rgba(120, 144, 255, 0.78),
+    0 0 var(--particle-aura) rgba(78, 93, 255, 0.32);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.7);
+  animation: pf-codex-wall-particle 560ms cubic-bezier(0.16, 1, 0.3, 1) var(--particle-delay) both;
+}
+
+@keyframes pf-codex-burst-life {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes pf-codex-wall-particle {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.55);
+  }
+
+  18% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform:
+      translate(
+        calc(-50% + var(--particle-tx)),
+        calc(-50% + var(--particle-ty))
+      )
+      scale(0.12);
+  }
+}
+
 .pf-ambassador-k {
   display: block;
   margin-bottom: 0.18rem;
@@ -90,7 +149,8 @@
   box-shadow: var(--pf-shadow);
 }
 
-.pf-portrait-stage::before {
+/* Add is-inner-wall-enabled to .pf-portrait-stage to restore the inset guide. */
+.pf-portrait-stage.is-inner-wall-enabled::before {
   content: "";
   position: absolute;
   inset: 0.85rem;

--- a/js/playfolio/motion.js
+++ b/js/playfolio/motion.js
@@ -1,3 +1,130 @@
+const WALL_PARTICLE_SPREADS = [-0.82, -0.52, -0.25, 0, 0.25, 0.52, 0.82];
+const CODEX_SPEED_ACCELERATION_PER_SECOND = 0.52;
+const CODEX_MAX_SPEED_MULTIPLIER = 2.45;
+const MAX_ACTIVE_WALL_BURSTS = 4;
+const LAUNCH_MIN_VERTICAL_ABS = 0.34;
+const MIN_APPROACH_VECTOR_LENGTH = 2;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function formatPercent(value) {
+  return `${clamp(value, 0, 100).toFixed(2)}%`;
+}
+
+function normalizeVector(x, y) {
+  const length = Math.hypot(x, y) || 1;
+
+  return { x: x / length, y: y / length };
+}
+
+function accelerateBall(ball, dt) {
+  const currentSpeed = Math.hypot(ball.vx, ball.vy);
+  if (!currentSpeed || currentSpeed >= ball.maxSpeed) return;
+
+  const nextSpeed = Math.min(
+    ball.maxSpeed,
+    currentSpeed * (1 + CODEX_SPEED_ACCELERATION_PER_SECOND * dt),
+  );
+  const scale = nextSpeed / currentSpeed;
+  ball.vx *= scale;
+  ball.vy *= scale;
+}
+
+function createRandomLaunchVelocity(speed) {
+  const angle = Math.random() * Math.PI * 2;
+  let x = Math.cos(angle);
+  let y = Math.sin(angle);
+
+  if (x < 0 && y > 0) {
+    x *= -1;
+  }
+
+  if (Math.abs(y) < LAUNCH_MIN_VERTICAL_ABS) {
+    y = y < 0 ? -LAUNCH_MIN_VERTICAL_ABS : LAUNCH_MIN_VERTICAL_ABS;
+  }
+
+  const direction = normalizeVector(x, y);
+
+  return {
+    vx: direction.x * speed,
+    vy: direction.y * speed,
+  };
+}
+
+function createApproachLaunchVelocity(speed, rect, event) {
+  if (!rect || !Number.isFinite(event?.clientX) || !Number.isFinite(event?.clientY)) return null;
+
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const x = centerX - event.clientX;
+  const y = centerY - event.clientY;
+  if (Math.hypot(x, y) < MIN_APPROACH_VECTOR_LENGTH) return null;
+
+  const direction = normalizeVector(x, y);
+
+  return {
+    vx: direction.x * speed,
+    vy: direction.y * speed,
+  };
+}
+
+export function createCodexWallHitParticles(stage, {
+  x,
+  y,
+  normalX,
+  normalY,
+  speed,
+  skipMotion = false,
+} = {}) {
+  if (!stage || skipMotion) return null;
+
+  const activeBursts = Array.from(stage.querySelectorAll?.('.pf-codex-wall-burst') || []);
+  const staleBurstCount = activeBursts.length - MAX_ACTIVE_WALL_BURSTS + 1;
+  if (staleBurstCount > 0) {
+    activeBursts.slice(0, staleBurstCount).forEach((activeBurst) => activeBurst.remove());
+  }
+
+  const ownerDocument = stage.ownerDocument || document;
+  const burst = ownerDocument.createElement('span');
+  const intensity = clamp((Number(speed) || 0) / 900, 0.7, 1.45);
+  const distance = 28 + intensity * 4;
+  const normal = normalizeVector(Number(normalX) || 0, Number(normalY) || 0);
+  const tangent = { x: -normal.y, y: normal.x };
+
+  burst.classList.add('pf-codex-wall-burst');
+  burst.setAttribute?.('aria-hidden', 'true');
+  burst.style.setProperty('--burst-x', formatPercent(x));
+  burst.style.setProperty('--burst-y', formatPercent(y));
+  burst.style.setProperty('--burst-intensity', intensity.toFixed(2));
+
+  WALL_PARTICLE_SPREADS.forEach((spread, index) => {
+    const particle = ownerDocument.createElement('span');
+    const direction = normalizeVector(
+      normal.x + tangent.x * spread,
+      normal.y + tangent.y * spread,
+    );
+
+    particle.classList.add('pf-codex-wall-particle');
+    particle.style.setProperty('--particle-dx', direction.x.toFixed(4));
+    particle.style.setProperty('--particle-dy', direction.y.toFixed(4));
+    particle.style.setProperty('--particle-distance', `${distance.toFixed(2)}px`);
+    particle.style.setProperty('--particle-tx', `${(direction.x * distance).toFixed(2)}px`);
+    particle.style.setProperty('--particle-ty', `${(direction.y * distance).toFixed(2)}px`);
+    particle.style.setProperty('--particle-delay', `${index * 12}ms`);
+    particle.style.setProperty('--particle-size', `${(3.5 + intensity * 1.6 - Math.abs(spread)).toFixed(2)}px`);
+    particle.style.setProperty('--particle-glow', `${(8 * intensity).toFixed(2)}px`);
+    particle.style.setProperty('--particle-aura', `${(18 * intensity).toFixed(2)}px`);
+    burst.appendChild(particle);
+  });
+
+  burst.addEventListener('animationend', () => burst.remove(), { once: true });
+  stage.appendChild(burst);
+
+  return burst;
+}
+
 export function setupPortraitCycle(root = document) {
   const image = root.querySelector('[data-portrait-cycle]');
   if (!image) return;
@@ -41,6 +168,31 @@ export function setupCodexAmbassadorLogo(root = document) {
   let videoLoaded = false;
   let frameId = 0;
   let ball = null;
+
+  const emitWallParticles = ({ normalX, normalY, speed }) => {
+    if (!ball?.stage) return;
+    const currentLeft = ball.originX + ball.x;
+    const currentTop = ball.originY + ball.y;
+    const impactX = normalX < 0
+      ? currentLeft + ball.logoWidth
+      : normalX > 0
+        ? currentLeft
+        : currentLeft + ball.logoWidth / 2;
+    const impactY = normalY < 0
+      ? currentTop + ball.logoHeight
+      : normalY > 0
+        ? currentTop
+        : currentTop + ball.logoHeight / 2;
+
+    createCodexWallHitParticles(ball.stage, {
+      x: (impactX / ball.stageWidth) * 100,
+      y: (impactY / ball.stageHeight) * 100,
+      normalX,
+      normalY,
+      speed,
+      skipMotion: reducedMotionQuery.matches,
+    });
+  };
 
   const loadAmbassadorVideo = () => {
     if (!video || !videoSource || videoLoaded || shouldSkipVideo()) return;
@@ -96,17 +248,26 @@ export function setupCodexAmbassadorLogo(root = document) {
     ball.y += ball.vy * dt;
 
     if (ball.x <= ball.bounds.minX || ball.x >= ball.bounds.maxX) {
+      const normalX = ball.vx > 0 ? -1 : 1;
+      const impactSpeed = Math.hypot(ball.vx, ball.vy);
+
       ball.x = Math.max(ball.bounds.minX, Math.min(ball.bounds.maxX, ball.x));
       ball.vx *= -1;
       ball.angle += ball.vy > 0 ? 58 : -58;
+      emitWallParticles({ normalX, normalY: 0, speed: impactSpeed });
     }
 
     if (ball.y <= ball.bounds.minY || ball.y >= ball.bounds.maxY) {
+      const normalY = ball.vy > 0 ? -1 : 1;
+      const impactSpeed = Math.hypot(ball.vx, ball.vy);
+
       ball.y = Math.max(ball.bounds.minY, Math.min(ball.bounds.maxY, ball.y));
       ball.vy *= -1;
       ball.angle += ball.vx > 0 ? -43 : 43;
+      emitWallParticles({ normalX: 0, normalY, speed: impactSpeed });
     }
 
+    accelerateBall(ball, dt);
     ball.angle += (ball.vx > 0 ? 460 : -460) * dt;
 
     if (!ball.hasLeftHome && !isNearHome()) {
@@ -122,7 +283,7 @@ export function setupCodexAmbassadorLogo(root = document) {
     frameId = window.requestAnimationFrame(tickBall);
   };
 
-  const startBall = () => {
+  const startBall = (event) => {
     loadAmbassadorVideo();
     if (reducedMotionQuery.matches || ball) return;
 
@@ -132,24 +293,32 @@ export function setupCodexAmbassadorLogo(root = document) {
     const stageRect = stage.getBoundingClientRect();
     const rect = logo.getBoundingClientRect();
     const speed = Math.max(760, Math.min(stageRect.width, stageRect.height) * 1.9);
+    const launchVelocity = createApproachLaunchVelocity(speed, rect, event) || createRandomLaunchVelocity(speed);
     const now = performance.now();
-    const margin = Math.max(24, rect.width * 0.32);
 
     ball = {
       x: 0,
       y: 0,
-      vx: speed,
-      vy: -speed * 0.64,
+      vx: launchVelocity.vx,
+      vy: launchVelocity.vy,
+      maxSpeed: speed * CODEX_MAX_SPEED_MULTIPLIER,
       angle: 0,
       startedAt: now,
       lastTime: now,
       hasLeftHome: false,
+      stage,
+      stageWidth: stageRect.width,
+      stageHeight: stageRect.height,
+      originX: rect.left - stageRect.left,
+      originY: rect.top - stageRect.top,
+      logoWidth: rect.width,
+      logoHeight: rect.height,
       homeRadius: Math.max(34, rect.width * 0.55),
       bounds: {
-        minX: stageRect.left + margin - rect.left,
-        maxX: stageRect.right - margin - rect.right,
-        minY: stageRect.top + margin - rect.top,
-        maxY: stageRect.bottom - margin - rect.bottom,
+        minX: stageRect.left - rect.left,
+        maxX: stageRect.right - rect.right,
+        minY: stageRect.top - rect.top,
+        maxY: stageRect.bottom - rect.bottom,
       },
     };
 

--- a/tests/unit/playfolio/motion.test.js
+++ b/tests/unit/playfolio/motion.test.js
@@ -1,0 +1,371 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createCodexWallHitParticles, setupCodexAmbassadorLogo } from '../../../js/playfolio/motion.js';
+
+function createClassList() {
+  const classes = new Set();
+
+  return {
+    add: (...names) => names.forEach((name) => classes.add(name)),
+    remove: (...names) => names.forEach((name) => classes.delete(name)),
+    contains: (name) => classes.has(name),
+  };
+}
+
+function createStyle() {
+  const props = new Map();
+
+  return {
+    setProperty: vi.fn((name, value) => props.set(name, value)),
+    getPropertyValue: (name) => props.get(name),
+    _props: props,
+  };
+}
+
+function createElement(tagName) {
+  const listeners = new Map();
+  const children = [];
+  const element = {
+    tagName,
+    children,
+    classList: createClassList(),
+    style: createStyle(),
+    appendChild: vi.fn((child) => {
+      children.push(child);
+      child.parentNode = element;
+      return child;
+    }),
+    remove: vi.fn(() => {
+      element.wasRemoved = true;
+    }),
+    addEventListener: vi.fn((eventName, handler) => listeners.set(eventName, handler)),
+    _listeners: listeners,
+  };
+
+  return element;
+}
+
+function createCodexLogoHarness({
+  reducedMotion = false,
+  stageRect = {
+    left: 100,
+    right: 200,
+    top: 100,
+    bottom: 200,
+    width: 100,
+    height: 100,
+  },
+  logoRect = {
+    left: 145,
+    right: 195,
+    top: 145,
+    bottom: 195,
+    width: 50,
+    height: 50,
+  },
+} = {}) {
+  const listeners = new Map();
+  let frameCallback = null;
+  const stageChildren = [];
+  const ownerDocument = {
+    createElement: vi.fn((tagName) => createElement(tagName)),
+  };
+  const stage = {
+    ownerDocument,
+    appendChild: vi.fn((child) => {
+      stageChildren.push(child);
+      child.parentNode = stage;
+      return child;
+    }),
+    getBoundingClientRect: vi.fn(() => stageRect),
+  };
+  const logo = {
+    classList: createClassList(),
+    style: {},
+    querySelector: vi.fn(() => null),
+    closest: vi.fn((selector) => (selector === '.pf-portrait-stage' ? stage : null)),
+    getBoundingClientRect: vi.fn(() => logoRect),
+    addEventListener: vi.fn((eventName, handler) => listeners.set(eventName, handler)),
+  };
+  const root = {
+    querySelector: vi.fn((selector) => (selector === '[data-codex-ambassador-logo]' ? logo : null)),
+  };
+
+  global.window = {
+    matchMedia: vi.fn(() => ({ matches: reducedMotion })),
+    requestAnimationFrame: vi.fn((callback) => {
+      frameCallback = callback;
+      return 1;
+    }),
+    cancelAnimationFrame: vi.fn(),
+    addEventListener: vi.fn(),
+  };
+  vi.spyOn(performance, 'now').mockReturnValue(1000);
+
+  return {
+    logo,
+    listeners,
+    root,
+    stage,
+    stageChildren,
+    runFrame: (time = 2000) => frameCallback(time),
+  };
+}
+
+function parseTranslate3d(transform) {
+  const numberPattern = '-?\\d+(?:\\.\\d+)?(?:e[+-]?\\d+)?';
+  const match = transform.match(new RegExp(`translate3d\\((${numberPattern})px, (${numberPattern})px, 0\\)`, 'i'));
+
+  return match ? { x: Number(match[1]), y: Number(match[2]) } : null;
+}
+
+describe('playfolio motion behavior', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete global.window;
+  });
+
+  test('does not draw an internal portrait-stage wall', () => {
+    const css = readFileSync(path.join(process.cwd(), 'css/playfolio/motion.css'), 'utf8');
+
+    expect(css).not.toContain('.pf-portrait-stage::before');
+    expect(css).toContain('.pf-portrait-stage.is-inner-wall-enabled::before');
+  });
+
+  test('lets the Codex logo hit the portrait-stage wall without a collision margin', () => {
+    const harness = createCodexLogoHarness();
+    vi.spyOn(Math, 'random').mockReturnValue(0.85);
+
+    setupCodexAmbassadorLogo(harness.root);
+    harness.listeners.get('pointerenter')();
+    harness.runFrame();
+
+    expect(parseTranslate3d(harness.logo.style.transform)).toEqual({
+      x: 5,
+      y: expect.any(Number),
+    });
+    expect(parseTranslate3d(harness.logo.style.transform).y).toBeLessThan(0);
+  });
+
+  test('creates directional speed-scaled Codex particles when the logo hits a wall', () => {
+    const harness = createCodexLogoHarness();
+    vi.spyOn(Math, 'random').mockReturnValue(0.85);
+
+    setupCodexAmbassadorLogo(harness.root);
+    harness.listeners.get('pointerenter')();
+    harness.runFrame();
+
+    expect(harness.stageChildren.length).toBeGreaterThanOrEqual(1);
+    const burst = harness.stageChildren[0];
+    expect(burst.classList.contains('pf-codex-wall-burst')).toBe(true);
+    expect(burst.style.getPropertyValue('--burst-x')).toBe('100.00%');
+    expect(Number(burst.style.getPropertyValue('--burst-y').replace('%', ''))).toBeLessThan(60);
+    expect(Number(burst.style.getPropertyValue('--burst-intensity'))).toBeGreaterThan(0.7);
+    expect(burst.children).toHaveLength(7);
+
+    const firstParticle = burst.children[0];
+    expect(firstParticle.classList.contains('pf-codex-wall-particle')).toBe(true);
+    expect(Number(firstParticle.style.getPropertyValue('--particle-dx'))).toBeLessThan(0);
+    expect(Math.abs(Number(firstParticle.style.getPropertyValue('--particle-dy')))).toBeGreaterThan(0);
+    expect(Number(firstParticle.style.getPropertyValue('--particle-distance').replace('px', ''))).toBeGreaterThan(30);
+    expect(Number(firstParticle.style.getPropertyValue('--particle-tx').replace('px', ''))).toBeLessThan(0);
+    expect(Number(firstParticle.style.getPropertyValue('--particle-glow').replace('px', ''))).toBeGreaterThan(5);
+
+    burst._listeners.get('animationend')();
+    expect(burst.remove).toHaveBeenCalled();
+  });
+
+  test('accelerates the Codex logo within a flying run until it resets', () => {
+    const harness = createCodexLogoHarness({
+      stageRect: {
+        left: 100,
+        right: 1100,
+        top: 100,
+        bottom: 1100,
+        width: 1000,
+        height: 1000,
+      },
+      logoRect: {
+        left: 200,
+        right: 250,
+        top: 200,
+        bottom: 250,
+        width: 50,
+        height: 50,
+      },
+    });
+    vi.spyOn(Math, 'random').mockReturnValue(0.85);
+
+    setupCodexAmbassadorLogo(harness.root);
+    harness.listeners.get('pointerenter')();
+
+    harness.runFrame(1016);
+    const firstPosition = parseTranslate3d(harness.logo.style.transform);
+    harness.runFrame(1032);
+    const secondPosition = parseTranslate3d(harness.logo.style.transform);
+
+    expect(secondPosition.x - firstPosition.x).toBeGreaterThan(firstPosition.x);
+  });
+
+  test('does not stop a Codex flight solely because wall-clock time elapsed', () => {
+    const harness = createCodexLogoHarness({
+      stageRect: {
+        left: 100,
+        right: 1100,
+        top: 100,
+        bottom: 1100,
+        width: 1000,
+        height: 1000,
+      },
+      logoRect: {
+        left: 200,
+        right: 250,
+        top: 200,
+        bottom: 250,
+        width: 50,
+        height: 50,
+      },
+    });
+    vi.spyOn(Math, 'random').mockReturnValue(0.25);
+
+    setupCodexAmbassadorLogo(harness.root);
+    harness.listeners.get('pointerenter')();
+    harness.runFrame(1016);
+    expect(harness.logo.classList.contains('is-flying')).toBe(true);
+
+    harness.runFrame(10050);
+
+    expect(harness.logo.classList.contains('is-flying')).toBe(true);
+    expect(harness.logo.style.transform).toContain('translate3d(');
+  });
+
+  test('uses the mouse approach direction when pointer coordinates are available', () => {
+    const harness = createCodexLogoHarness({
+      stageRect: {
+        left: 100,
+        right: 1100,
+        top: 100,
+        bottom: 1100,
+        width: 1000,
+        height: 1000,
+      },
+      logoRect: {
+        left: 200,
+        right: 250,
+        top: 200,
+        bottom: 250,
+        width: 50,
+        height: 50,
+      },
+    });
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.25);
+
+    setupCodexAmbassadorLogo(harness.root);
+    harness.listeners.get('pointerenter')({ clientX: 200, clientY: 225 });
+    harness.runFrame(1016);
+    const firstDirection = parseTranslate3d(harness.logo.style.transform);
+
+    expect(firstDirection.x).toBeGreaterThan(0);
+    expect(Math.abs(firstDirection.y)).toBeLessThan(0.0001);
+    expect(randomSpy).not.toHaveBeenCalled();
+  });
+
+  test('starts each Codex logo flight with a randomized direction while preserving launch speed', () => {
+    const baseHarness = createCodexLogoHarness({
+      stageRect: {
+        left: 100,
+        right: 1100,
+        top: 100,
+        bottom: 1100,
+        width: 1000,
+        height: 1000,
+      },
+      logoRect: {
+        left: 200,
+        right: 250,
+        top: 200,
+        bottom: 250,
+        width: 50,
+        height: 50,
+      },
+    });
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    setupCodexAmbassadorLogo(baseHarness.root);
+    baseHarness.listeners.get('pointerenter')();
+    baseHarness.runFrame(1016);
+    const firstDirection = parseTranslate3d(baseHarness.logo.style.transform);
+
+    vi.restoreAllMocks();
+
+    const alternateHarness = createCodexLogoHarness({
+      stageRect: {
+        left: 100,
+        right: 1100,
+        top: 100,
+        bottom: 1100,
+        width: 1000,
+        height: 1000,
+      },
+      logoRect: {
+        left: 200,
+        right: 250,
+        top: 200,
+        bottom: 250,
+        width: 50,
+        height: 50,
+      },
+    });
+    vi.spyOn(Math, 'random').mockReturnValue(0.25);
+
+    setupCodexAmbassadorLogo(alternateHarness.root);
+    alternateHarness.listeners.get('pointerenter')();
+    alternateHarness.runFrame(1016);
+    const secondDirection = parseTranslate3d(alternateHarness.logo.style.transform);
+
+    expect(secondDirection).not.toEqual(firstDirection);
+    expect(Math.hypot(secondDirection.x, secondDirection.y)).toBeCloseTo(Math.hypot(firstDirection.x, firstDirection.y), 6);
+  });
+
+  test('does not create wall particles when reduced motion is enabled', () => {
+    const stage = {
+      ownerDocument: { createElement: vi.fn() },
+      appendChild: vi.fn(),
+    };
+
+    createCodexWallHitParticles(stage, {
+      x: 100,
+      y: 50,
+      normalX: -1,
+      normalY: 0,
+      speed: 900,
+      skipMotion: true,
+    });
+
+    expect(stage.appendChild).not.toHaveBeenCalled();
+  });
+
+  test('bounds active wall bursts so fast runs cannot accumulate stale DOM', () => {
+    const existingBursts = Array.from({ length: 6 }, () => ({ remove: vi.fn() }));
+    const stage = {
+      ownerDocument: { createElement: vi.fn((tagName) => createElement(tagName)) },
+      appendChild: vi.fn(),
+      querySelectorAll: vi.fn(() => existingBursts),
+    };
+
+    createCodexWallHitParticles(stage, {
+      x: 100,
+      y: 50,
+      normalX: -1,
+      normalY: 0,
+      speed: 900,
+    });
+
+    expect(existingBursts[0].remove).toHaveBeenCalled();
+    expect(existingBursts[1].remove).toHaveBeenCalled();
+    expect(existingBursts[2].remove).toHaveBeenCalled();
+    expect(existingBursts[3].remove).not.toHaveBeenCalled();
+    expect(stage.appendChild).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This pull request introduces significant enhancements to the Codex Ambassador logo animation in Playfolio, focusing on more dynamic wall collision effects, improved motion logic, and robust testing. The main changes include adding animated particle bursts when the logo hits the wall, refining the physics and launch direction of the logo, and updating both CSS and tests to support and verify these features.

**Codex wall collision effects and motion improvements:**

* Added animated particle burst and wall particle effects on logo-wall collisions, including new CSS classes (`.pf-codex-wall-burst`, `.pf-codex-wall-particle`) and keyframes for the animation.
* Implemented the `createCodexWallHitParticles` function in `motion.js` to generate and manage particle bursts on wall impact, including logic to limit the number of active bursts and remove stale DOM elements.
* Enhanced the physics of the Codex logo flight: added acceleration over time, improved collision detection (including impact direction and speed), and randomized or pointer-based launch directions. [[1]](diffhunk://#diff-6c6682e5266c7354eccf6af17d5188bfbc9e4d83e7e43e1d67eb67d95235faa7R172-R196) [[2]](diffhunk://#diff-6c6682e5266c7354eccf6af17d5188bfbc9e4d83e7e43e1d67eb67d95235faa7R251-R270) [[3]](diffhunk://#diff-6c6682e5266c7354eccf6af17d5188bfbc9e4d83e7e43e1d67eb67d95235faa7L125-R286) [[4]](diffhunk://#diff-6c6682e5266c7354eccf6af17d5188bfbc9e4d83e7e43e1d67eb67d95235faa7R296-R321)

**CSS adjustments:**

* Changed the `.pf-portrait-stage::before` selector to require the `.is-inner-wall-enabled` class, preventing the wall guide from displaying by default and making it opt-in.

**Testing improvements:**

* Added comprehensive unit tests for the new motion and particle burst features, including tests for collision detection, particle creation, acceleration, launch direction, reduced motion support, and DOM cleanup.